### PR TITLE
use cryptographically secure prng for nonces

### DIFF
--- a/BitID.php
+++ b/BitID.php
@@ -55,9 +55,7 @@ class BitID {
      * @return string
      */
     public function generateNonce($length = 16) {
-        $dict = array_merge(range('a', 'z'), range('0', '9'), range('A', 'Z'));
-        shuffle($dict);
-        return substr(hash('sha512', mt_rand() . implode('', $dict)), 0, $length);
+        return bin2hex(openssl_random_pseudo_bytes($length));
     }
 
     /**

--- a/struct.sql
+++ b/struct.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `tbl_nonces` (
   `s_ip` varchar(46) COLLATE utf8_bin NOT NULL,
   `dt_datetime` datetime NOT NULL,
-  `s_nonce` varchar(16) COLLATE utf8_bin NOT NULL,
+  `s_nonce` varchar(32) COLLATE utf8_bin NOT NULL,
   `s_address` varchar(34) COLLATE utf8_bin DEFAULT NULL,
   UNIQUE KEY `s_nonce` (`s_nonce`),
   KEY `dt_datetime` (`dt_datetime`)


### PR DESCRIPTION
generateNonce uses mt_rand and shuffle, both of which are seeded only by the timestamp and pid
If you can guess someone's nonce you can spam requests to ajax.php and get logged in as them the next time they try to sign on
